### PR TITLE
Implement version strategy

### DIFF
--- a/Samples/Media.Domain.Tests/AutoFixtureParameterSource.cs
+++ b/Samples/Media.Domain.Tests/AutoFixtureParameterSource.cs
@@ -26,7 +26,7 @@ namespace Media.Domain.Tests
             yield return GetParameterValues(method.GetParameters(), fixture);
         }
 
-        object[] GetParameterValues(ParameterInfo[] parameters, IFixture fixture)
+        static object[] GetParameterValues(IEnumerable<ParameterInfo> parameters, IFixture fixture)
         {
             return parameters
                 .Select(p => fixture.Resolve(p.ParameterType))

--- a/Samples/Media.Domain.Tests/Customizations/DeviceCustomization.cs
+++ b/Samples/Media.Domain.Tests/Customizations/DeviceCustomization.cs
@@ -11,7 +11,7 @@ namespace Media.Domain.Tests.Customizations
 
     sealed class DeviceCustomization : PickRandomItemFromFixedSequenceCustomization<Type>
     {
-        public DeviceCustomization() : base (new Type[] {typeof(Microphone), typeof(VideoCamera) })
+        public DeviceCustomization() : base (new[] {typeof(Microphone), typeof(VideoCamera) })
         {
         }
 

--- a/Samples/Media.Domain.Tests/Media.Domain.Tests.csproj
+++ b/Samples/Media.Domain.Tests/Media.Domain.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\packages\build\Microsoft.Net.Compilers\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\packages\build\Microsoft.Net.Compilers\build\Microsoft.Net.Compilers.props')" Label="Paket" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Samples/Media.Domain.Tests/MicrophoneTests.cs
+++ b/Samples/Media.Domain.Tests/MicrophoneTests.cs
@@ -23,7 +23,7 @@ namespace Media.Domain.Tests
             microphone.IsInRole(RoleInActivity.Recording(audioRecording)).ShouldBeTrue();
         }
 
-        void CannotUseForAudioRecordingWhenAlreadyRecording(
+        public void CannotUseForAudioRecordingWhenAlreadyRecording(
             Microphone microphone,
             ActivityId previousAudioRecording,
             ActivityId newAudioRecording)
@@ -33,7 +33,7 @@ namespace Media.Domain.Tests
             microphone.UseForAudioRecording(newAudioRecording).ShouldBeFalse();
         }
 
-        void ShouldBeAvailableWhenStoppingUseForAudioRecording(
+        public void ShouldBeAvailableWhenStoppingUseForAudioRecording(
             Microphone microphone,
             ActivityId audioRecording)
         {

--- a/Samples/Media.Domain.Tests/Properties/AssemblyInfo.cs
+++ b/Samples/Media.Domain.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Samples/Media.Domain.Tests/VideoCameraTests.cs
+++ b/Samples/Media.Domain.Tests/VideoCameraTests.cs
@@ -23,7 +23,7 @@ namespace Media.Domain.Tests
             videoCamera.IsInRole(RoleInActivity.Recording(videoRecording)).ShouldBeTrue();
         }
 
-        void CannotUseForVideoRecordingWhenAlreadyRecording(
+        public void CannotUseForVideoRecordingWhenAlreadyRecording(
             VideoCamera videoCamera,
             ActivityId previousVideoRecording,
             ActivityId newVideoRecording)

--- a/Samples/Media.Domain.Tests/paket.references
+++ b/Samples/Media.Domain.Tests/paket.references
@@ -2,6 +2,7 @@ Fixie
 
 group Build
   RefactoringEssentials
+  Microsoft.Net.Compilers
 
 group Test
   AutoFixture.Idioms

--- a/Samples/Media.Domain/Media.Domain.csproj
+++ b/Samples/Media.Domain/Media.Domain.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\packages\build\Microsoft.Net.Compilers\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\packages\build\Microsoft.Net.Compilers\build\Microsoft.Net.Compilers.props')" Label="Paket" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Samples/Media.Domain/ValueObject.cs
+++ b/Samples/Media.Domain/ValueObject.cs
@@ -37,12 +37,7 @@ namespace Media.Domain
         /// </returns>
         public static bool operator ==(ValueObject<T> lhs, ValueObject<T> rhs)
         {
-            if (ReferenceEquals(lhs, null))
-            {
-                return true;
-            }
-
-            return lhs.Equals(rhs);
+            return ReferenceEquals(lhs, null) || lhs.Equals(rhs);
         }
 
         /// <summary>

--- a/Samples/Media.Domain/paket.references
+++ b/Samples/Media.Domain/paket.references
@@ -2,3 +2,6 @@ group Build
   StyleCop.Analyzers
   CodeCracker.CSharp
   RefactoringEssentials
+  Microsoft.Net.Compilers
+
+  

--- a/Samples/Media.Specifications/Media.Specifications.csproj
+++ b/Samples/Media.Specifications/Media.Specifications.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\packages\build\Microsoft.Net.Compilers\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\packages\build\Microsoft.Net.Compilers\build\Microsoft.Net.Compilers.props')" Label="Paket" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Samples/Media.Specifications/Properties/AssemblyInfo.cs
+++ b/Samples/Media.Specifications/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Samples/Media.Specifications/SpecificationConvention.cs
+++ b/Samples/Media.Specifications/SpecificationConvention.cs
@@ -21,7 +21,7 @@ namespace Media.Specifications
                 .UsingFactory(CreateFromFixture);
         }
 
-        object CreateFromFixture(Type type)
+        static object CreateFromFixture(Type type)
         {
             var fixture = new Fixture();
 

--- a/Samples/Media.Specifications/paket.references
+++ b/Samples/Media.Specifications/paket.references
@@ -2,6 +2,7 @@ Fixie
 
 group Build
   RefactoringEssentials
+  Microsoft.Net.Compilers
 
 group Test
   AutoFixture

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    master:
+    master
       configuration: Release
       deploy: NuGet
   except:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ pull_requests:
   do_not_increment_build_number: true
 
 branches:
-only:
+  only:
     master
 
 configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,6 @@ version: '{build}'
 pull_requests:
   do_not_increment_build_number: true
 
-branches:
-  only:
-    - master
-
 configuration: Release
 
 nuget:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,24 +1,25 @@
+version: '{build}'
+
+pull_requests:
+  do_not_increment_build_number: true
+
 # configuration for "master" branch
-branches:
-  only:
-    master
+-
+  branches:
+    only:
+      master
 
-configuration: Release
-deploy: NuGet
+  configuration: Release
+  deploy: NuGet
 
-# configuration for all other branches
-branches:
-  except:
-    - gh-pages
+# Fall back configuration for all other branches
+-
+  configuration: Debug
 
-configuration: Debug
-
-init:
-  - git config --global core.autocrlf input
 build_script:
   - cmd: build.cmd NuGet
+
 test: off
-version: {build}
 
 artifacts:
   - path: artifacts\*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,18 +3,12 @@ version: '{build}'
 pull_requests:
   do_not_increment_build_number: true
 
-# configuration for "master" branch
--
-  branches:
-    only:
-      master
+branches:
+only:
+    master
 
-  configuration: Release
-  deploy: NuGet
-
-# Fall back configuration for all other branches
--
-  configuration: Debug
+configuration: Release
+deploy: NuGet
 
 build_script:
   - cmd: build.cmd NuGet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,32 @@
+branches:
+  only:
+    master:
+      configuration: Release
+      deploy: NuGet
+  except:
+    - gh-pages
+
+configuration: Debug
+
 init:
   - git config --global core.autocrlf input
 build_script:
   - cmd: build.cmd NuGet
 test: off
-version: 0.0.1.{build}
+version: {build}
+
 artifacts:
-  - path: artifacts
-    name: artifacts
+  - path: artifacts\*.nupkg
+    name: Nuget
+
+nuget:
+  disable_publish_on_pr: true
+
+deploy:
+- provider: NuGet
+  name: production
+  api_key:
+    secure: 34adee4b-cbc2-4a78-bede-ce0e8ada13c8
+  on:
+    branch: master
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,27 +1,55 @@
-version: '{build}'
+# All branches are debug build on all commits, but are not published
+-
+  version: '{build}'
 
-pull_requests:
-  do_not_increment_build_number: true
+  branches:
+    except:
+      - master
 
-configuration: Release
+  pull_requests:
+    do_not_increment_build_number: true
 
-nuget:
-  disable_publish_on_pr: true
+  configuration: Debug
 
-build_script:
-  - cmd: build.cmd NuGet
+  build_script:
+    - cmd: build.cmd NuGet
 
-test: off
+  test: off
 
-artifacts:
-  - path: artifacts\*.nupkg
-    name: Nuget
+  artifacts:
+    - path: artifacts\*.nupkg
+      name: Nuget
 
-deploy:
-- provider: NuGet
-  name: production
-  api_key:
-    secure: 34adee4b-cbc2-4a78-bede-ce0e8ada13c8
-  on:
-    branch: master
-    appveyor_repo_tag: true
+# Master branch are release builds only on version tags and published to Nuget
+-
+  version: '{build}'
+
+  branches:
+    only:
+      - master
+
+  pull_requests:
+    do_not_increment_build_number: true
+
+  configuration: Release
+
+  nuget:
+    disable_publish_on_pr: true
+
+  build_script:
+    - cmd: build.cmd NuGet
+
+  test: off
+
+  artifacts:
+    - path: artifacts\*.nupkg
+      name: Nuget
+
+  deploy:
+  - provider: NuGet
+    name: production
+    api_key:
+      secure: 34adee4b-cbc2-4a78-bede-ce0e8ada13c8
+    on:
+      branch: master
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,13 @@
+# configuration for "master" branch
 branches:
   only:
     master
-      configuration: Release
-      deploy: NuGet
+
+configuration: Release
+deploy: NuGet
+
+# configuration for all other branches
+branches:
   except:
     - gh-pages
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,12 @@ pull_requests:
 
 branches:
   only:
-    master
+    - master
 
 configuration: Release
+
+nuget:
+  disable_publish_on_pr: true
 
 build_script:
   - cmd: build.cmd NuGet
@@ -17,9 +20,6 @@ test: off
 artifacts:
   - path: artifacts\*.nupkg
     name: Nuget
-
-nuget:
-  disable_publish_on_pr: true
 
 deploy:
 - provider: NuGet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ only:
     master
 
 configuration: Release
-deploy: NuGet
 
 build_script:
   - cmd: build.cmd NuGet

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,5 @@
 @echo off
+SETLOCAL
 cls
 
 .paket\paket.bootstrapper.exe
@@ -12,7 +13,7 @@ if errorlevel 1 (
 )
 
 if [%1] == [] (
-    packages\build\FAKE\tools\FAKE.exe build.fsx --listTargets
+    packages\build\FAKE\tools\FAKE.exe build.fsx "Default"
 ) else (
     packages\build\FAKE\tools\FAKE.exe build.fsx %*
 )

--- a/build.fsx
+++ b/build.fsx
@@ -35,7 +35,7 @@ let description = "A super low friction specification test framework based on th
 let authors = [ "Martin Bohring" ]
 
 // Tags for your project (for NuGet package)
-let tags = "FixieSpec, Fixie, BDD, TDD, unit testing"
+let tags = "FixieSpec Fixie BDD TDD unit testing"
 
 // File system information 
 // (<solutionFile>.sln is built during the building process)

--- a/build.fsx
+++ b/build.fsx
@@ -42,10 +42,10 @@ let tags = "FixieSpec Fixie BDD TDD unit testing"
 let solutionFile  = "FixieSpec"
 
 // The build output directory of all projects
-let buildDir = "build"
+let buildDir = "./build"
 
 // The directory for all artifacts (nugets, docs etc.)
-let artifactsDir = "artifacts"
+let artifactsDir = "./artifacts"
 
 // Pattern specifying assemblies to be tested
 let testAssemblies = buildDir + "/*Tests*.dll"
@@ -68,6 +68,7 @@ let (|Fsproj|Csproj|Vbproj|Shproj|) (projFileName:string) =
     | f when f.EndsWith("shproj") -> Shproj
     | _                           -> failwith (sprintf "Project file %s not supported. Unknown project type." projFileName)
 
+// --------------------------------------------------------------------------------------
 // Generate assembly info files with the right version & up-to-date information
 Target "AssemblyInfo" (fun _ ->
     let getAssemblyInfoAttributes projectName =

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -14,6 +14,7 @@ group Build
   nuget StyleCop.Analyzers
   nuget CodeCracker.CSharp prerelease
   nuget RefactoringEssentials
+  github fsharp/FAKE modules/Octokit/Octokit.fsx
 
 group Test
   redirects: on

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -14,8 +14,8 @@ group Build
   nuget StyleCop.Analyzers
   nuget CodeCracker.CSharp prerelease
   nuget RefactoringEssentials
-  github fsharp/FAKE modules/Octokit/Octokit.fsx
-
+  nuget Microsoft.Net.Compilers
+  
 group Test
   redirects: on
 

--- a/paket.lock
+++ b/paket.lock
@@ -11,7 +11,7 @@ NUGET
     codecracker.CSharp (1.0)
     FAKE (4.29.2)
     Microsoft.Net.Compilers (1.3.2)
-    RefactoringEssentials (4.1)
+    RefactoringEssentials (4.2)
     SourceLink.Fake (1.1)
     StyleCop.Analyzers (1.0)
 
@@ -20,10 +20,10 @@ STRATEGY: MIN
 NUGET
   remote: https://www.nuget.org/api/v2
     Albedo (1.0.1)
-    AutoFixture (3.48)
-    AutoFixture.Idioms (3.48)
+    AutoFixture (3.49)
+    AutoFixture.Idioms (3.49)
       Albedo (>= 1.0.1)
-      AutoFixture (>= 3.48)
+      AutoFixture (>= 3.49)
     Microsoft.CSharp (4.0.1-rc2-24027) - framework: >= netstandard13
       System.Collections (>= 4.0.11-rc2-24027) - framework: dnxcore50, >= netstandard13
       System.Diagnostics.Debug (>= 4.0.11-rc2-24027) - framework: dnxcore50, >= netstandard13

--- a/paket.lock
+++ b/paket.lock
@@ -10,21 +10,11 @@ NUGET
   remote: https://www.nuget.org/api/v2
     codecracker.CSharp (1.0)
     FAKE (4.29.2)
-    Microsoft.Bcl (1.1.10) - framework: net10, net11, net20, net30, net35, net40, net40-full
-      Microsoft.Bcl.Build (>= 1.0.14)
-    Microsoft.Bcl.Build (1.0.21) - import_targets: false, framework: net10, net11, net20, net30, net35, net40, net40-full
-    Microsoft.Net.Http (2.2.29) - framework: net10, net11, net20, net30, net35, net40, net40-full
-      Microsoft.Bcl (>= 1.1.10)
-      Microsoft.Bcl.Build (>= 1.0.14)
-    Octokit (0.20)
-      Microsoft.Net.Http  - framework: net10, net11, net20, net30, net35, net40, net40-full
+    Microsoft.Net.Compilers (1.3.2)
     RefactoringEssentials (4.1)
     SourceLink.Fake (1.1)
     StyleCop.Analyzers (1.0)
-GITHUB
-  remote: fsharp/FAKE
-    modules/Octokit/Octokit.fsx (c56456abac6b744c3bb95b217687db19fd19b367)
-      Octokit (>= 0.20)
+
 GROUP Test
 STRATEGY: MIN
 NUGET

--- a/paket.lock
+++ b/paket.lock
@@ -10,10 +10,21 @@ NUGET
   remote: https://www.nuget.org/api/v2
     codecracker.CSharp (1.0)
     FAKE (4.29.2)
+    Microsoft.Bcl (1.1.10) - framework: net10, net11, net20, net30, net35, net40, net40-full
+      Microsoft.Bcl.Build (>= 1.0.14)
+    Microsoft.Bcl.Build (1.0.21) - import_targets: false, framework: net10, net11, net20, net30, net35, net40, net40-full
+    Microsoft.Net.Http (2.2.29) - framework: net10, net11, net20, net30, net35, net40, net40-full
+      Microsoft.Bcl (>= 1.1.10)
+      Microsoft.Bcl.Build (>= 1.0.14)
+    Octokit (0.20)
+      Microsoft.Net.Http  - framework: net10, net11, net20, net30, net35, net40, net40-full
     RefactoringEssentials (4.1)
     SourceLink.Fake (1.1)
     StyleCop.Analyzers (1.0)
-
+GITHUB
+  remote: fsharp/FAKE
+    modules/Octokit/Octokit.fsx (c56456abac6b744c3bb95b217687db19fd19b367)
+      Octokit (>= 0.20)
 GROUP Test
 STRATEGY: MIN
 NUGET

--- a/src/FixieSpec/FixieSpec.csproj
+++ b/src/FixieSpec/FixieSpec.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\packages\build\Microsoft.Net.Compilers\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\packages\build\Microsoft.Net.Compilers\build\Microsoft.Net.Compilers.props')" Label="Paket" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/src/FixieSpec/FixieSpecConvention.cs
+++ b/src/FixieSpec/FixieSpecConvention.cs
@@ -34,8 +34,8 @@ namespace FixieSpec
                 .Skip(SkipWhenAssertionStepIsInconclusive);
 
             FixtureExecution
-                .Wrap(new ExecuteSpecificationSteps((method) => method.IsTransitionStep()))
-                .Wrap(new ExecuteSpecificationSteps((method) => method.IsSetupStep()));
+                .Wrap(new ExecuteSpecificationSteps(method => method.IsTransitionStep()))
+                .Wrap(new ExecuteSpecificationSteps(method => method.IsSetupStep()));
         }
 
         static bool SkipWhenSpecificationIsInconclusive(Case @case)

--- a/src/FixieSpec/paket.references
+++ b/src/FixieSpec/paket.references
@@ -4,3 +4,5 @@ group Build
   StyleCop.Analyzers
   CodeCracker.CSharp
   RefactoringEssentials
+  Microsoft.Net.Compilers
+  

--- a/src/FixieSpec/paket.template
+++ b/src/FixieSpec/paket.template
@@ -12,5 +12,6 @@ excludeddependencies
   StyleCop.Analyzers
   CodeCracker.CSharp
   RefactoringEssentials
+  Microsoft.Net.Compilers
 
 include-pdbs true

--- a/tests/FixieSpec.Tests/DeclarationOrderComparerTests.cs
+++ b/tests/FixieSpec.Tests/DeclarationOrderComparerTests.cs
@@ -28,7 +28,7 @@ namespace FixieSpec.Tests
         public void ShouldDeclareNullMethodAsEarlier()
         {
             var result = testee.Compare(
-                null as MethodInfo,
+                null,
                 firstMethod);
 
             result.ShouldBe(-1);
@@ -54,7 +54,7 @@ namespace FixieSpec.Tests
 
         public void ShouldCompareBothNullAsSame()
         {
-            var result = testee.Compare(null as MethodInfo, null as MethodInfo);
+            var result = testee.Compare(null, null);
 
             result.ShouldBe(0);
         }

--- a/tests/FixieSpec.Tests/FixieSpec.Tests.csproj
+++ b/tests/FixieSpec.Tests/FixieSpec.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\packages\build\Microsoft.Net.Compilers\build\Microsoft.Net.Compilers.props" Condition="Exists('..\..\packages\build\Microsoft.Net.Compilers\build\Microsoft.Net.Compilers.props')" Label="Paket" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/tests/FixieSpec.Tests/Properties/AssemblyInfo.cs
+++ b/tests/FixieSpec.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/tests/FixieSpec.Tests/paket.references
+++ b/tests/FixieSpec.Tests/paket.references
@@ -1,5 +1,8 @@
 Fixie
 
+group Build
+  Microsoft.Net.Compilers
+
 group Test
   AutoFixture.Idioms
   Shouldly


### PR DESCRIPTION
- Got version specific AppVeyor build configuration resolved.
- Their [documentation ](https://www.appveyor.com/docs/branches)is a bit misleading and guides you into creating an invalid yaml file. Look at the `Conditional build configuration` example.
- Github releases will be addressed later on
- Also pulled in the Roslyn compiler to allow buidling in .Net 4.5 environments (which is the target framework anyway)

This fixes issue #13 